### PR TITLE
fix {up,down}loadSpeed not being enumerable

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,10 +64,12 @@ module.exports = function (archive, opts) {
   })
 
   Object.defineProperty(speed, 'downloadSpeed', {
+    enumerable: true,
     get: function () { return downloadSpeed() }
   })
 
   Object.defineProperty(speed, 'uploadSpeed', {
+    enumerable: true,
     get: function () { return uploadSpeed() }
   })
 

--- a/test.js
+++ b/test.js
@@ -32,6 +32,7 @@ function tests () {
 
     archive.once('upload', function () {
       t.ok(speed.uploadSpeed && speed.uploadSpeed > 0, 'has upload speed')
+      t.ok(Object.keys(speed).indexOf('uploadSpeed') > -1, 'uploadSpeed enumerable')
       archiveClient.close(function () {
         swarmClient.close(function () {
           t.end()
@@ -49,6 +50,7 @@ function tests () {
     archiveClient.open(function () {
       archiveClient.content.once('download', function () {
         t.ok(speed.downloadSpeed && speed.downloadSpeed > 0, 'has download speed')
+        t.ok(Object.keys(speed).indexOf('downloadSpeed') > -1, 'downloadSpeed enumerable')
         archiveClient.close(function () {
           swarmClient.close(function () {
             t.end()


### PR DESCRIPTION
makes it easier to work with, eg when using `JSON.stringify()` on the speed value